### PR TITLE
Fixed mcrypt and ssl cert issue

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -79,6 +79,3 @@ chown -R www-data:www-data $WEBROOT/var
 # stop mysql
 /etc/init.d/mysql stop
 
-# Finishing up
-mv /usr/lib/inithooks/firstboot.d/15regen-sslcert /usr/lib/inithooks/firstboot.d/45regen-sslcert
-

--- a/conf.d/main
+++ b/conf.d/main
@@ -79,3 +79,6 @@ chown -R www-data:www-data $WEBROOT/var
 # stop mysql
 /etc/init.d/mysql stop
 
+# Finishing up
+mv /usr/lib/inithooks/firstboot.d/15regen-sslcert /usr/lib/inithooks/firstboot.d/45regen-sslcert
+

--- a/plan/main
+++ b/plan/main
@@ -4,5 +4,6 @@
 php5-cli
 php5-curl
 php5-gd
+php5-mcrypt
 
 patch


### PR DESCRIPTION
To fix the invalid ssl cert issue (No ssl cert with valid server name) I renamed 15regen-sslcert to 45regen-sslcert (so hostname is changed before new ssl generated).

Closes https://github.com/turnkeylinux/tracker/issues/392